### PR TITLE
fix: Use StrongPtr::retain on class methods

### DIFF
--- a/src/base.rs
+++ b/src/base.rs
@@ -30,7 +30,7 @@ pub struct NSArray<T> {
 impl<T> NSArray<T> {
     pub fn array_with_objects(objects: Vec<Id>) -> NSArray<T> {
         unsafe {
-            let p = StrongPtr::new(
+            let p = StrongPtr::retain(
                 msg_send![class!(NSArray), arrayWithObjects:objects.as_slice().as_ptr() count:objects.len()],
             );
             NSArray {

--- a/src/virtualization/network_device.rs
+++ b/src/virtualization/network_device.rs
@@ -72,7 +72,7 @@ impl VZMACAddress {
     }
     pub fn random_locally_administered_address() -> VZMACAddress {
         let p = unsafe {
-            StrongPtr::new(msg_send![
+            StrongPtr::retain(msg_send![
                 class!(VZMACAddress),
                 randomLocallyAdministeredAddress
             ])


### PR DESCRIPTION
Resolves #4 

I am not good at Objective-C and/or macOS things, so I do not know this is the correct resolution of this issue. However I confirmed this works without occurring any segmentation faults.